### PR TITLE
improves keys

### DIFF
--- a/api/spec/hyperion/key_spec.clj
+++ b/api/spec/hyperion/key_spec.clj
@@ -23,10 +23,18 @@
   (it "composes unique keys"
     (should= 100 (count (into #{} (take 100 (repeatedly #(compose-key "foo"))))))
     (should= 100 (count (into #{} (take 100 (repeatedly #(compose-key "bar"))))))
-    (should= (encode-key "foo:123") (compose-key "foo" 123)))
+    (should= (compose-key "foo" 123) (compose-key "foo" 123)))
 
   (it "decomposes keys"
-    (let [key (encode-key "foo:abc123")]
+    (let [key (compose-key "foo" "abc123")]
       (should= ["foo" "abc123"] (decompose-key key))))
+
+  (it "decomposes keys containing a :"
+    (let [key (compose-key "foo" "abc:123")]
+      (should= ["foo" "abc:123"] (decompose-key key))))
+
+  (it "decomposes keys kind as a keyword"
+    (let [key (compose-key :foo "abc:123")]
+      (should= ["foo" "abc:123"] (decompose-key key))))
 
   )

--- a/api/src/hyperion/key.clj
+++ b/api/src/hyperion/key.clj
@@ -1,5 +1,6 @@
 (ns hyperion.key
-  (:require [clojure.data.codec.base64 :refer [encode decode]]))
+  (:require [clojure.data.codec.base64 :refer [encode decode]]
+            [hyperion.abstr :refer :all]))
 
 (defn encode-key [value]
   (.replace
@@ -22,7 +23,8 @@
 
 (defn compose-key
   ([kind] (compose-key kind (generate-id)))
-  ([kind id] (encode-key (str kind ":" id))))
+  ([kind id] (encode-key (str (encode-key (->kind kind)) ":" (encode-key (str id))))))
 
 (defn decompose-key [key]
-  (seq (.split (decode-key key) ":")))
+  (map decode-key (.split (decode-key key) ":")))
+

--- a/sql/spec/hyperion/sql/key_spec.clj
+++ b/sql/spec/hyperion/sql/key_spec.clj
@@ -11,7 +11,7 @@
     (should-not= (compose-key "foo" 1) (compose-key "bar" 1)))
 
   (it "can parse a key"
-    (let [key (String. (encode (.getBytes (str "foo:123"))))]
+    (let [key (compose-key :foo 123)]
       (should= ["foo" 123] (decompose-key key))))
 
   )


### PR DESCRIPTION
This fixes an issue where a key can contain a ":"

However, in the implementation, I encode the string twice - this may not be best.

Any suggestions?
