### PR TITLE
Bumped version number in the readme v3.2>v3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Hyperion Implementations:
 ### Leiningen
 
 ```clojure
-:dependencies [[hyperion/hyperion-<impl here> "3.2.0"]]
+:dependencies [[hyperion/hyperion-<impl here> "3.4.0"]]
 ```
 
 ## Usage


### PR DESCRIPTION
The readme lists v3.2, changed to current v3.4.
